### PR TITLE
remove build scripts from fastly.toml

### DIFF
--- a/fastly.toml
+++ b/fastly.toml
@@ -1,12 +1,5 @@
-# This file describes a Fastly Compute@Edge package. To learn more visit:
-# https://developer.fastly.com/reference/fastly-toml/
-
 authors = ["<oss@fastly.com>"]
 description = "Enables Fanout on a service, forwarding to a backend."
 language = "rust"
 manifest_version = 2
 name = "Fanout forwarding starter for Rust"
-service_id = ""
-
-[scripts]
-  build = "cargo build --bin fastly-compute-project --release --target wasm32-wasi --color always"


### PR DESCRIPTION
Context: https://github.com/fastly/compute-starter-kit-rust-static-content/pull/22#discussion_r1088904863