### PR TITLE
Adding service version logging

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,9 @@ fn take_non_empty_body(req: &mut Request) -> Result<Option<Body>, Error> {
 }
 
 fn main() -> Result<(), Error> {
+    // Log service version
+    println!("FASTLY_SERVICE_VERSION: {}", std::env::var("FASTLY_SERVICE_VERSION").unwrap_or_else(|_| String::new()));
+    
     let mut req = Request::from_client();
 
     if let Some(body) = take_non_empty_body(&mut req)? {


### PR DESCRIPTION
Prints service version to console after running `fastly log-tail`. ([JIRA ticket](https://fastly.atlassian.net/browse/DEVLIB-856?atlOrigin=eyJpIjoiMDY0MmI0YThjZDVhNGE5NjljZjBiZGNjNTkzOWY2NDMiLCJwIjoiaiJ9))