### PR TITLE
Update into a simple "fanout forward" starter kit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ publish = false
 debug = 1
 
 [dependencies]
-fastly = "0.10.0"
+fastly = "0.11.0"

--- a/fastly.toml
+++ b/fastly.toml
@@ -1,8 +1,11 @@
+# This file describes a Fastly Compute package. To learn more visit:
+# https://www.fastly.com/documentation/reference/compute/fastly-toml
+
 authors = ["<oss@fastly.com>"]
 description = "Enables Fanout on a service, forwarding to a backend."
 language = "rust"
-manifest_version = 2
-name = "Fanout forwarding"
+manifest_version = 3
+name = "Fanout forwarding starter kit for Rust"
 
 [scripts]
   build = "cargo build --bin fastly-compute-project --release --target wasm32-wasi --color always"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use fastly::{Error, Request};
+use fastly::http::{HeaderValue, Method};
 
 fn main() -> Result<(), Error> {
     // Log service version.
@@ -9,5 +10,39 @@ fn main() -> Result<(), Error> {
 
     let req = Request::from_client();
 
-    Ok(req.handoff_fanout("origin")?)
+    let mut use_fanout = false;
+
+    if req.get_method() == &Method::GET &&
+        req.get_header_all("upgrade")
+            .collect()
+            .contains(&&HeaderValue::from_static("websocket"))
+    {
+        // If a GET request contains "Upgrade: websocket" in its headers, then hand off to Fanout
+        // to handle as WebSocket-over-HTTP.
+        // For details on WebSocket-over-HTTP, see https://pushpin.org/docs/protocols/websocket-over-http/
+        use_fanout = true;
+    } else if req.get_method() == &Method::GET || req.get_method() == &Method::HEAD {
+        // If it's a GET or HEAD request, then hand off to Fanout.
+        // The backend response can include GRIP control messages to specify connection behavior.
+        // For details on GRIP, see https://pushpin.org/docs/protocols/grip/.
+
+        // NOTE: In an actual app we would be selective about which requests are handed off to Fanout,
+        // because requests that are handed off to Fanout do not pass through the Fastly cache.
+        // For example, we may examine the request path or the existence of certain headers.
+        // See https://www.fastly.com/documentation/guides/concepts/real-time-messaging/fanout/#what-to-hand-off-to-fanout
+
+        // TODO: add any additional conditions before setting use_fanout to true
+
+        use_fanout = true;
+    }
+
+    if use_fanout {
+        // Hand off the request through Fanout to the specified backend.
+        req.handoff_fanout("origin")?
+    } else {
+        // Send the request to the specified backend normally.
+        req.send("origin")?.send_to_client()
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
This is now going to be a separate starter kit from https://github.com/fastly/compute-starter-kit-rust-fanout that can be used in the simple case of acting as a GRIP proxy for WebSocket and GET/HEAD requests.

Added some additional instructions on how to expand the kit going forward.