### PR TITLE
Use .any() instead of .collect()

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,9 +14,7 @@ fn main() -> Result<(), Error> {
 
     if req.get_method() == &Method::GET &&
         req.get_header_all("upgrade")
-            .collect()
-            .contains(&&HeaderValue::from_static("websocket"))
-    {
+            .any(|value| value == &HeaderValue::from_static("websocket")) {
         // If a GET request contains "Upgrade: websocket" in its headers, then hand off to Fanout
         // to handle as WebSocket-over-HTTP.
         // For details on WebSocket-over-HTTP, see https://pushpin.org/docs/protocols/websocket-over-http/


### PR DESCRIPTION
This gives type inference problems

```rust
        req.get_header_all("upgrade")
            .collect()
            .contains(&&HeaderValue::from_static("websocket"))
```

```
    Checking fastly-compute-project v0.1.0 (/Users/komuro/Developer/fastly/compute-starter-kit-rust-fanout-forward)
error[E0282]: type annotations needed
  --> src/main.rs:17:14
   |
17 |             .collect()
   |              ^^^^^^^ cannot infer type of the type parameter `B` declared on the method `collect`
   |
help: consider specifying the generic argument
   |
17 |             .collect::<Vec<_>>()
   |                     ++++++++++

For more information about this error, try `rustc --explain E0282`.
```

So replacing with
```rust
        req.get_header_all("upgrade")
            .any(|value| value == &HeaderValue::from_static("websocket")) {
```